### PR TITLE
Fix modal CSS bug

### DIFF
--- a/css/estilos.css
+++ b/css/estilos.css
@@ -343,7 +343,6 @@ section.catalogo {
   width: 100vw;
   height: 100vh;
   background-color: rgba(0,0,0,0.8);
-  display: flex;
   align-items: center;
   justify-content: center;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- hide modal by default in CSS so it doesn't flash on page load

## Testing
- `php -l index.php`

------
https://chatgpt.com/codex/tasks/task_e_68896d11515c8321aa1220e86e473112